### PR TITLE
Get it back working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/*.sqlite
+/example/node_modules
+node_modules
+*.db
+config.json
+/example/config.json

--- a/example/index.html
+++ b/example/index.html
@@ -49,10 +49,11 @@
         request.onload = function (e) {
             console.log(e);
             track.clearLayers();
+console.log(e);
             track.addData(JSON.parse(e.currentTarget.response));
             map.fitBounds(track.getBounds());
         }
-
+console.log(mmsi)
         request.open('get', '/marinetraffic?mmsi=' + mmsi, true);
         request.send();
     };
@@ -61,7 +62,7 @@
     control.onAdd = function (map) {
         var input = L.DomUtil.create('input', 'mmsi');
         input.id = 'mmsi';
-        input.value = '244543000';
+        input.value = '230981000';
         L.DomEvent.disableClickPropagation(input);
         L.DomEvent.disableScrollPropagation(input);
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var http = require('http');
+var https = require('https');
 var _ = require('underscore');
 
 // swap an [lat, lng]-array, or an array of [lat, lng]-arrays.
@@ -195,13 +195,13 @@ var xml2json = function (xml, callback) {
         if (err) {
             callback(err);
         }
-        if (!json.TRACK || !json.TRACK.POS) {
+        if (!json.VESSELTRACK || !json.VESSELTRACK.POSITION) {
             callback(new Error('Unexpected XML contents'));
             return;
         }
 
         var track = [];
-        json.TRACK.POS.forEach(function (point) {
+        json.VESSELTRACK.POSITION.forEach(function (point) {
             point = point.$;
             track.push({
                 latlng: [parseFloat(point.LAT), parseFloat(point.LON)],
@@ -210,7 +210,6 @@ var xml2json = function (xml, callback) {
                 timestamp: point.TIMESTAMP
             });
         });
-
         callback(null, fromJson(track));
     });
 };
@@ -220,9 +219,9 @@ module.exports = function (mmsi, callback) {
         return;
     }
 
-    var vesselTrackUrl = 'http://mob0.marinetraffic.com/ais/gettrackxml.aspx?mmsi=';
+    var vesselTrackUrl = 'https://services.marinetraffic.com/api/exportvesseltrack/YOURAPIKEY/v:2/period:daily/days:5/mmsi:';
 
-    http.get(vesselTrackUrl + mmsi, function (res) {
+    https.get(vesselTrackUrl + mmsi, function (res) {
         var data = '';
 
         res.on('data', function (chunk) {

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ module.exports = function (mmsi, callback) {
         return;
     }
 
-    var vesselTrackUrl = 'https://services.marinetraffic.com/api/exportvesseltrack/YOURAPIKEY/v:2/period:daily/days:5/mmsi:';
+    var vesselTrackUrl = 'https://services.marinetraffic.com/api/exportvesseltrack/2876731050cb171e40f66c30744ca76742b325d6/v:2/period:hourly/days:1/mmsi:';
 
     https.get(vesselTrackUrl + mmsi, function (res) {
         var data = '';

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "author": "Jan Pieter Waagmeester <jieter@jieter.nl>",
   "license": "MIT",
   "dependencies": {
-    "xml2js": "~0.2.8",
-    "underscore": "~1.5.1"
+    "xml2js": "~0.4.19",
+    "underscore": "~1.9.1"
   },
   "devDependencies": {
-    "mocha": "~1.12.0",
-    "chai": "~1.8.0"
+    "mocha": "~6.1.4",
+    "chai": "~4.2.0"
   }
 }


### PR DESCRIPTION
The used API is not working anymore. 
Marinetraffic offers a new API-Service, similar to the old one: https://help.marinetraffic.com/hc/en-us/sections/115000594772-API-Services

It requires an account with a personal API key. As the data format is a bit different, I made minor adjustments to get this thing back to work.